### PR TITLE
KademliaDHT: do not add closer on sendToNode

### DIFF
--- a/src/Pos/DHT/Real/Real.hs
+++ b/src/Pos/DHT/Real/Real.hs
@@ -270,7 +270,8 @@ instance ( MonadDialog (BiP DHTMsgHeader) m
     sendToNeighbors = defaultSendToNeighbors seqConcurrentlyK sendToNode
     sendToNode addr msg = do
         defaultSendToNode addr msg
-        listenOutbound >>= updateClosers
+        listenOutbound
+        pure ()
       where
         -- [CSL-4][TW-47]: temporary code, to refactor to subscriptions (after TW-47)
         listenOutboundDo = KademliaDHT (asks kdcListenByBinding) >>= ($ AtConnTo addr)
@@ -280,8 +281,6 @@ instance ( MonadDialog (BiP DHTMsgHeader) m
             logDebug $ sformat ("Error listening outbound connection to " %
                                 shown % ": " % build) addr e
             return $ pure ()
-        updateClosers closer = KademliaDHT (asks kdcAuxClosers)
-                            >>= \tvar -> (atomically $ modifyTVar tvar (closer:))
 
 rejoinNetwork
     :: (MonadIO m, WithLogger m, MonadCatch m, Bi DHTData, Bi DHTKey)


### PR DESCRIPTION
The closers are cleared only when the DHT is stopped. So remembering the
closer for each 'sendToNode' is a memory leak. It seems these closers
aren't necessary in practice, for when the DHT is stopped, the main
thread comes to an end and all threads will die anyway. If a set of
threads must be killed at a certain point, I recommend using a safer
abstraction like async.