### PR TITLE
travis-ci: build also OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
-sudo: true
-os:
-  - linux
-  # TODO: enable once rocksdb builds
-  #- osx
 language: nix
+sudo: true
+matrix:
+    include:
+        - os: osx
+          osx_image: xcode7.3
+        - os: osx
+          osx_image: xcode8
+        - os: osx
+          osx_image: xcode8.2
 env:
-  - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/e18dac705ad36482880e23d0a89c60c3514cb446.tar.gz
+  - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/addcb0dddf2b7db505dae5c38fceb691c7ed85f9.tar.gz
 cache:
   directories:
   - "$HOME/.stack"
@@ -18,7 +22,7 @@ before_install:
 - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
 - travis_retry curl -L https://www.stackage.org/stack/$TRAVIS_OS_NAME-x86_64 | tar xz --strip-components=1 -C ~/.local/bin
 - nix-shell --run ":"
-- stack --nix --no-terminal build --nix --test --no-haddock-deps --ghc-options="-j +RTS -A128m -n2m -RTS" --only-dependencies --jobs=4 --flag cardano-sl:with-web --flag cardano-sl:with-wallet
+- stack --nix --no-terminal build --nix --fast --test --no-haddock-deps --ghc-options="-j +RTS -A128m -n2m -RTS" --only-dependencies --jobs=4 --flag cardano-sl:with-web --flag cardano-sl:with-wallet
 
 # --fast and ghc-options greatly improve CI build times
 script:

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
-with import (fetchTarball https://github.com/NixOS/nixpkgs/archive/e18dac705ad36482880e23d0a89c60c3514cb446.tar.gz) { };
+with import (fetchTarball https://github.com/NixOS/nixpkgs/archive/663048f37849667f84bb1d941132369eff6e630f.tar.gz) { };
 
 let
-  hsPkgs = haskell.packages.ghc801;
+  hsPkgs = haskell.packages.ghc802;
 in
   haskell.lib.buildStackProject {
      name = "cardano-sl";
@@ -10,6 +10,7 @@ in
        zlib openssh autoreconfHook openssl
        gmp rocksdb git
      # cabal-install and stack pull in lots of dependencies on OSX so skip them
+     # See https://github.com/NixOS/nixpkgs/issues/21200
      ] ++ (lib.optionals stdenv.isLinux [ cabal-install stack ]);
      LANG = "en_US.UTF-8";
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
 
 - location:
     git: https://github.com/serokell/universum
-    commit: 32316939cd9239fc283d4d562508e67767020fcf
+    commit: db3cd301545e5da000e53ca2cdf274e0386192bf
   extra-dep: true
 - location:
     git: https://github.com/serokell/log-warper.git


### PR DESCRIPTION
1) builds the app on three different versions of OSX

- El Captain using xcode 7
- El Captain using xcode 8
- Sierra using xcode 8.2 

2) bumps default compiler to GHC 8.0.2-rc2 **when using Nix**

- this is required for some OSX problems (adds support for OSX Sierra)
- [support for using `stack --fast`](https://ghc.haskell.org/trac/ghc/ticket/12076)
- supports parallel Nix builds
- faster Nix compilation times than with GHC 8.0.1 due to `-split-sections` over `-split-objs`
- further improvements will come to 8.0.2
