### PR TITLE
Fix postinstall hook

### DIFF
--- a/daedalus/package.json
+++ b/daedalus/package.json
@@ -5,7 +5,7 @@
   "main": "output/Daedalus.ClientApi/index.js",
   "scripts": {
     "start": "npm run build:dev",
-    "postinstall": "bower cache clean && bower install && npm run build",
+    "postinstall": "bower cache clean && bower install && npm run build:dev",
     "clean": "rimraf dist && rimraf output",
     "build:prod": "npm run clean && mkdir dist && NODE_ENV=prod ./node_modules/.bin/webpack --config webpack.config.js --progress",
     "build:dev": "rimraf output && NODE_ENV=dev ./node_modules/.bin/webpack-dev-server --hot --config webpack.config.js --progress",

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,6 +36,7 @@ packages:
   extra-dep: true
 
 nix:
+  enable: true
   shell-file: shell.nix
 
 extra-deps:


### PR DESCRIPTION
That fixes post-install hook for `npm` for "fresh" builds of the daedalus bridge.